### PR TITLE
Change Opera version added 65 -> 66

### DIFF
--- a/javascript/operators/optional_chaining.json
+++ b/javascript/operators/optional_chaining.json
@@ -69,7 +69,7 @@
                 "version_added": "67"
               },
               {
-                "version_added": "65",
+                "version_added": "66",
                 "flags": [
                   {
                     "type": "preference",


### PR DESCRIPTION
It seems we forgot to bump the version of Opera when we bumped the version of Chrome.

I tested this to be true, just to be sure. Opera 66 supports Optional Chaining with `Experimental Javascript` enabled, while Opera 65 doesn't.

Issue was introduced in #5026

Original PR: #5011